### PR TITLE
changes to enable building as a submodule

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,6 @@
 [bumpversion]
-current_version = 0.0.0
+current_version = 0.1.0
 commit = True
 tag = True
 
 [bumpversion:file:CMake/HipBLASVersion.cmake]
-

--- a/CMake/HipBLASVersion.cmake
+++ b/CMake/HipBLASVersion.cmake
@@ -1,3 +1,3 @@
 # Copyright 2021-2023 UT-Battelle
 # See LICENSE.txt in the root of the source distribution for license info.
-set(HipBLAS_VERSION "0.0.0")
+set(HipBLAS_VERSION "0.1.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,14 @@
 # Copyright 2021-2023 UT-Battelle
 # See LICENSE.txt in the root of the source distribution for license info.
 cmake_minimum_required(VERSION 3.20)
-include (${CMAKE_SOURCE_DIR}/CMake/HipBLASVersion.cmake)
+
+# make sure the file pointed by LLVM_COMPILER exists
+if(NOT DEFINED ${LLVM_COMPILER})
+    message(FATAL_ERROR "LLVM_COMPILER must be set to the path of the LLVM compiler")
+endif()
+set(CMAKE_CXX_COMPILER ${LLVM_COMPILER})
+
+include (${CMAKE_CURRENT_SOURCE_DIR}/CMake/HipBLASVersion.cmake)
 project(HipBLAS
     VERSION ${HipBLAS_VERSION}
     LANGUAGES CXX)
@@ -16,7 +23,7 @@ project(HipBLAS
 #
 # We want to find CHIP-SPV's HIP support, which uses 'hip' (lower case)
 # as the name, not 'HIP' (upper case).
-find_package(hip REQUIRED)
+find_package(hip CONFIG REQUIRED)
 
 # Ensure our users and installed tests will be able to find our
 # dependency libraries.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,29 @@
 # Copyright 2021-2023 UT-Battelle
 # See LICENSE.txt in the root of the source distribution for license info.
+
 cmake_minimum_required(VERSION 3.20)
 
-# make sure the file pointed by LLVM_COMPILER exists
-if(NOT DEFINED ${LLVM_COMPILER})
-    message(FATAL_ERROR "LLVM_COMPILER must be set to the path of the LLVM compiler")
+# set the default CMAKE_INSTALL_PREFIX to the current directory/install
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE PATH "..." FORCE)
 endif()
-set(CMAKE_CXX_COMPILER ${LLVM_COMPILER})
+
+# print where MKLShim layer will be installed
+message(STATUS "H4I-HipBLAS will be installed to: ${CMAKE_INSTALL_PREFIX}")
 
 include (${CMAKE_CURRENT_SOURCE_DIR}/CMake/HipBLASVersion.cmake)
 project(HipBLAS
     VERSION ${HipBLAS_VERSION}
     LANGUAGES CXX)
 
+# check if CLANG_COMPILER_PATH was passed to CMake invocation, if not, look for clang++ in PATH
+if(NOT DEFINED CLANG_COMPILER_PATH)
+    find_program(CLANG_COMPILER_PATH clang++ REQUIRED)
+    message(STATUS "Found LLVM C++ Compiler: ${CLANG_COMPILER_PATH}")
+endif()
+
+set(CMAKE_CXX_COMPILER ${CLANG_COMPILER_PATH})
+set(CMAKE_CXX_COMPILER_ID "LLVM")
 
 # We will use HIP in some fashion, no matter which platform
 # we're targeting or what parts of the software we're building.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,12 @@
 # Copyright 2021-2023 UT-Battelle
 # See LICENSE.txt in the root of the source distribution for license info.
 
-# We rely on the MKL shim library.
-find_package(MKLShim REQUIRED)
+# set the default CMAKE_INSTALL_PREFIX to the current directory/install
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE PATH "..." FORCE)
+endif()
+
+
 
 # To aid portability between our implementation and
 # the ROCm hipBLAS implementation, we use the ROCm
@@ -17,12 +21,12 @@ ExternalProject_Add(ROCmHipblas
     PATCH_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    INSTALL_COMMAND sh ${CMAKE_SOURCE_DIR}/Scripts/install-hipblas-header.sh <SOURCE_DIR> ${CMAKE_BINARY_DIR} ${CMAKE_INSTALL_PREFIX}
+    INSTALL_COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/../Scripts/install-hipblas-header.sh <SOURCE_DIR> ${CMAKE_BINARY_DIR} ${CMAKE_INSTALL_PREFIX}
 )
 
 # Product the hipblas version header required by hipblas.h in recent ROCm versions.
 configure_file(
-    ${CMAKE_SOURCE_DIR}/include/hipblas-version.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/hipblas-version.h.in
     ${CMAKE_BINARY_DIR}/include/hipblas-version.h
     @ONLY)
 
@@ -32,17 +36,25 @@ add_library(hipblas SHARED
     hipblas.cpp)
 target_include_directories(hipblas
 	PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include;${CMAKE_BINARY_DIR}/include>"
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include;${CMAKE_BINARY_DIR}/include>"
 		$<INSTALL_INTERFACE:include>)
 # We need to be sure the ROCm HipBLAS library is downloaded and "installed"
 # (i.e., the hipblas.h header has been copied to the location we want) before
 # we build this library.
 add_dependencies(hipblas ROCmHipblas)
 
+# We rely on the MKL shim library.
+if(PROJECT_IS_TOP_LEVEL)
+    find_package(MKLShim REQUIRED)
+    set(MKL_SHIM H4I::MKLShim)
+else()
+    add_dependencies(hipblas MKLShim)
+    set(MKL_SHIM MKLShim)
+endif()
 target_link_libraries(hipblas
 	PRIVATE
         HipBLASCommonConfig
-        H4I::MKLShim
+        ${MKL_SHIM}
     PUBLIC
 		hip::host
     )
@@ -56,7 +68,7 @@ install(TARGETS hipblas
 install(FILES
 			${CMAKE_BINARY_DIR}/include/hipblas.h
 			${CMAKE_BINARY_DIR}/include/hipblas-version.h
-			${CMAKE_SOURCE_DIR}/include/hipblas-export.h
+			${CMAKE_CURRENT_SOURCE_DIR}/../include/hipblas-export.h
         TYPE INCLUDE
 )
 
@@ -67,7 +79,7 @@ install(EXPORT hipblas
 
 include(CMakePackageConfigHelpers)
 
-configure_package_config_file(${CMAKE_SOURCE_DIR}/CMake/HipBLASConfig.cmake.in
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/../CMake/HipBLASConfig.cmake.in
 	${CMAKE_CURRENT_BINARY_DIR}/hipblasConfig.cmake
 	PATH_VARS CMAKE_INSTALL_INCLUDEDIR
 	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipblas


### PR DESCRIPTION
Since hipBLAS is a very frequently used library,  it makes much more sense to be able to build it in a single step. 

This replaces the previous version which was a fork of Sabojit's branch.