### PR TITLE
Hardcode a new tag for hipblas.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 spack*.txt
 spack-build*/
+build/*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 if(NOT DEFINED HIP_VERSION_PATCH)
     message(FATAL_ERROR "HIP_VERSION_PATCH is not defined")
 endif()
-set(H4I_ROCM_HIPBLAS_TAG "rocm-${HIP_VERSION_MAJOR}.${HIP_VERSION_MINOR}.${HIP_VERSION_PATCH}" CACHE STRING "Tag to use from the ROCm hipBLAS repository when obtaining its hipblas.h header")
+set(H4I_ROCM_HIPBLAS_TAG "rocm-6.1.1" CACHE STRING "Tag to use from the ROCm hipBLAS repository when obtaining its hipblas.h header")
 ExternalProject_Add(ROCmHipblas
     GIT_REPOSITORY https://github.com/ROCmSoftwarePlatform/hipblas
     GIT_TAG ${H4I_ROCM_HIPBLAS_TAG}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,19 +5,7 @@
 # the ROCm hipBLAS implementation, we use the ROCm
 # hipBLAS library's hipblas.h header.
 include(ExternalProject)
-# make sure that HIP_VERSION_MAJOR, HIP_VERSION_MINOR, and HIP_VERSION_PATCH are defined
-if(NOT DEFINED HIP_VERSION_MAJOR)
-    message(FATAL_ERROR "HIP_VERSION_MAJOR is not defined")
-endif()
-
-if(NOT DEFINED HIP_VERSION_MINOR)
-    message(FATAL_ERROR "HIP_VERSION_MINOR is not defined")
-endif()
-
-if(NOT DEFINED HIP_VERSION_PATCH)
-    message(FATAL_ERROR "HIP_VERSION_PATCH is not defined")
-endif()
-set(H4I_ROCM_HIPBLAS_TAG "rocm-6.1.1" CACHE STRING "Tag to use from the ROCm hipBLAS repository when obtaining its hipblas.h header")
+option(H4I_ROCM_HIPBLAS_TAG "Tag to use from the ROCm hipBLAS repository when obtaining its hipblas.h header" "rocm-6.1.1")
 ExternalProject_Add(ROCmHipblas
     GIT_REPOSITORY https://github.com/ROCmSoftwarePlatform/hipblas
     GIT_TAG ${H4I_ROCM_HIPBLAS_TAG}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,19 @@
 # the ROCm hipBLAS implementation, we use the ROCm
 # hipBLAS library's hipblas.h header.
 include(ExternalProject)
-option(H4I_ROCM_HIPBLAS_TAG "Tag to use from the ROCm hipBLAS repository when obtaining its hipblas.h header" "rocm-5.3.0")
+# make sure that HIP_VERSION_MAJOR, HIP_VERSION_MINOR, and HIP_VERSION_PATCH are defined
+if(NOT DEFINED HIP_VERSION_MAJOR)
+    message(FATAL_ERROR "HIP_VERSION_MAJOR is not defined")
+endif()
+
+if(NOT DEFINED HIP_VERSION_MINOR)
+    message(FATAL_ERROR "HIP_VERSION_MINOR is not defined")
+endif()
+
+if(NOT DEFINED HIP_VERSION_PATCH)
+    message(FATAL_ERROR "HIP_VERSION_PATCH is not defined")
+endif()
+set(H4I_ROCM_HIPBLAS_TAG "rocm-${HIP_VERSION_MAJOR}.${HIP_VERSION_MINOR}.${HIP_VERSION_PATCH}" CACHE STRING "Tag to use from the ROCm hipBLAS repository when obtaining its hipblas.h header")
 ExternalProject_Add(ROCmHipblas
     GIT_REPOSITORY https://github.com/ROCmSoftwarePlatform/hipblas
     GIT_TAG ${H4I_ROCM_HIPBLAS_TAG}


### PR DESCRIPTION
Since hipBLAS directly depends on HIP,
we should always construct a proper tag based on HIP_VERSION instead of deafaulting.