### PR TITLE
fix: use POSIX test in install script

### DIFF
--- a/Scripts/install-hipblas-header.sh
+++ b/Scripts/install-hipblas-header.sh
@@ -2,7 +2,7 @@
 # Copyright 2021-2023 UT-Battelle
 # See LICENSE.txt in the root of the source distribution for license info.
 
-if (( $# != 3 ))
+if [ "$#" -ne 3 ]
 then
     echo "usage: $(basename $0) source_dir bindir inst_prefix" >&2
     exit 1


### PR DESCRIPTION
## Problem

`Scripts/install-hipblas-header.sh` has a `#!/bin/sh` shebang but used
`(( $# != 3 ))` on line 5, which is bash arithmetic syntax.  On systems
where `/bin/sh` is dash (Debian, Ubuntu, and most CI containers), this
produces:

```
install-hipblas-header.sh: 5: 3: not found
```

and the script exits with an error regardless of the argument count.

## Fix

Replace with the POSIX-compliant form:

```sh
if [ "$#" -ne 3 ]
```

This is equivalent in behavior and works under any POSIX-conformant shell.