### PR TITLE
Implement hipblasGetStream in the main library

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,6 +2,8 @@
 // See LICENSE.txt in the root of the source distribution for license info.
 #include <iostream>
 #include <atomic>
+#include <mutex>
+#include <unordered_map>
 #include "hip/hip_runtime.h"	// Necessary for CHIP-SPV implementation.
 #include "hip/hip_interop.h"	// Necessary for CHIP-SPV implementation.
 #include "hipblas.h"
@@ -13,6 +15,15 @@
 // As of now keeping it as global variable, in future
 // it will be part of Context so that different blas context can have it's own pointer mode
 std::atomic<int> POINTER_MODE;
+
+namespace {
+// MKLShim::Context does not carry the user's hipStream_t, but consumers
+// (e.g. libCEED's hip-ref backend) expect hipblasGetStream to return whatever
+// was last passed to hipblasSetStream. Track it in a side-map here rather than
+// adding a field to MKLShim::Context (avoids an ABI break in MKLShim).
+std::mutex g_handle_stream_mu;
+std::unordered_map<hipblasHandle_t, hipStream_t> g_handle_stream;
+}
 
 hipblasStatus_t
 hipblasSetPointerMode(hipblasHandle_t handle, hipblasPointerMode_t mode)
@@ -65,6 +76,10 @@ hipblasDestroy(hipblasHandle_t handle)
 {
     if(handle != nullptr)
     {
+        {
+            std::lock_guard<std::mutex> lk(g_handle_stream_mu);
+            g_handle_stream.erase(handle);
+        }
         H4I::MKLShim::Context* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
         H4I::MKLShim::Destroy(ctxt);
     }
@@ -89,8 +104,27 @@ hipblasSetStream(hipblasHandle_t handle, hipStream_t stream)
     unsigned long handles[nHandles];
     hipGetBackendNativeHandles(reinterpret_cast<uintptr_t>(stream), handles, 0);
     H4I::MKLShim::SetStream(ctxt, handles, nHandles);
+
+    std::lock_guard<std::mutex> lk(g_handle_stream_mu);
+    g_handle_stream[handle] = stream;
   }
   return (handle != nullptr) ? HIPBLAS_STATUS_SUCCESS : HIPBLAS_STATUS_HANDLE_IS_NULLPTR;
+}
+
+hipblasStatus_t
+hipblasGetStream(hipblasHandle_t handle, hipStream_t* streamId)
+{
+    if (handle == nullptr)
+        return HIPBLAS_STATUS_NOT_INITIALIZED;
+    if (streamId == nullptr)
+        return HIPBLAS_STATUS_INVALID_VALUE;
+
+    std::lock_guard<std::mutex> lk(g_handle_stream_mu);
+    auto it = g_handle_stream.find(handle);
+    // If no explicit stream was set, report the default (null) stream — this
+    // matches the behavior of the underlying MKLShim queue in that case.
+    *streamId = (it != g_handle_stream.end()) ? it->second : nullptr;
+    return HIPBLAS_STATUS_SUCCESS;
 }
 
 hipblasStatus_t


### PR DESCRIPTION
## Summary
- Adds `hipblasGetStream` to `libhipblas.so` — it was missing despite being part of the core hipBLAS API (companion to the existing `hipblasSetStream`).
- Downstream consumers (e.g. libCEED's hip-ref backend, which calls `hipblasGetStream` from `backends/hip-ref/ceed-hip-ref-vector.c`) were hitting runtime symbol lookup errors when linking with only `-lhipblas`. In a prior release this was patched with a supplementary `libhipblas_compat.so` shim, but that shim was dropped in 2026.03.17 — consumers then break again. Putting the symbol in the main library is the correct fix.
- Implementation uses a mutex-guarded side-map keyed by `hipblasHandle_t` to record the stream last passed to `hipblasSetStream`; `hipblasDestroy` erases the entry. Chose a side-map over adding a field to `MKLShim::Context` to avoid an ABI break in MKLShim.
- Returns `nullptr` (default stream) when no `hipblasSetStream` has been called, matching the underlying MKLShim queue behavior.

## Test plan
- [x] `hipblas_context_test` — PASS
- [x] `hipblas_simple_batched_test` — PASS
- [x] `hipblas_batched_correctness_test` — PASS (4/4 subcases: `Dgetrf`, `Dgetri`, `Cgetrf`, `SgemmStridedBatched`)
- [x] Ad-hoc round-trip check:
  - pre-`Set` → `Get` returns `nullptr` ✓
  - post-`Set` → `Get` returns the exact `hipStream_t` passed in ✓
  - error paths: `NOT_INITIALIZED` on null handle, `INVALID_VALUE` on null out-pointer ✓
- [x] `nm -D libhipblas.so | grep hipblasGetStream` — symbol is exported (`T`)