### PR TITLE
Add ILP64 (_64) wrapper functions for Level 1 BLAS

### DIFF
--- a/src/hipblas.cpp
+++ b/src/hipblas.cpp
@@ -10672,3 +10672,219 @@ hipblasStatus_t hipblasSgemmStridedBatchedEx(hipblasHandle_t   handle,
   
   HIPBLAS_CATCH("SGEMMSTRIDEDBATCHEDEX")
 }
+
+// ILP64 (int64_t) Level 1 BLAS functions.
+// These call MKLShim directly with native int64_t parameters, matching
+// the full implementation pattern (device pointer checks, etc.).
+
+hipblasStatus_t hipblasSasum_64(hipblasHandle_t handle, int64_t n, const float* x, int64_t incx, float* result) {
+  HIPBLAS_TRY
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipError_t hip_status;
+  bool is_result_dev_ptr = isDevicePointer(result);
+  if (incx <= 0) return HIPBLAS_STATUS_INVALID_VALUE;
+  if (n <= 0) {
+    if (is_result_dev_ptr) { hip_status = hipMemset(result, 0, sizeof(float)); }
+    else { *result = 0; }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+  float* dev_result = result;
+  if (!is_result_dev_ptr) { hip_status = hipMalloc(&dev_result, sizeof(float)); }
+  H4I::MKLShim::sAsum(ctxt, n, x, incx, dev_result);
+  if (!is_result_dev_ptr) {
+    hip_status = hipMemcpy(result, dev_result, sizeof(float), hipMemcpyDefault);
+    hip_status = hipFree(dev_result);
+  }
+  HIPBLAS_CATCH("ASUM_64")
+}
+
+hipblasStatus_t hipblasDasum_64(hipblasHandle_t handle, int64_t n, const double* x, int64_t incx, double* result) {
+  HIPBLAS_TRY
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipError_t hip_status;
+  bool is_result_dev_ptr = isDevicePointer(result);
+  if (incx <= 0) return HIPBLAS_STATUS_INVALID_VALUE;
+  if (n <= 0) {
+    if (is_result_dev_ptr) { hip_status = hipMemset(result, 0, sizeof(double)); }
+    else { *result = 0; }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+  double* dev_result = result;
+  if (!is_result_dev_ptr) { hip_status = hipMalloc(&dev_result, sizeof(double)); }
+  H4I::MKLShim::dAsum(ctxt, n, x, incx, dev_result);
+  if (!is_result_dev_ptr) {
+    hip_status = hipMemcpy(result, dev_result, sizeof(double), hipMemcpyDefault);
+    hip_status = hipFree(dev_result);
+  }
+  HIPBLAS_CATCH("ASUM_64")
+}
+
+hipblasStatus_t hipblasSaxpy_64(hipblasHandle_t handle, int64_t n, const float* alpha,
+                                const float* x, int64_t incx, float* y, int64_t incy) {
+  HIPBLAS_TRY
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  bool is_dev_ptr = isDevicePointer(alpha);
+  float host_alpha = 0;
+  if (is_dev_ptr) { auto s = hipMemcpy(&host_alpha, alpha, sizeof(float), hipMemcpyDefault); }
+  else { host_alpha = *alpha; }
+  H4I::MKLShim::sAxpy(ctxt, n, host_alpha, x, incx, y, incy);
+  HIPBLAS_CATCH("AXPY_64")
+}
+
+hipblasStatus_t hipblasDaxpy_64(hipblasHandle_t handle, int64_t n, const double* alpha,
+                                const double* x, int64_t incx, double* y, int64_t incy) {
+  HIPBLAS_TRY
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  bool is_dev_ptr = isDevicePointer(alpha);
+  double host_alpha = 0;
+  if (is_dev_ptr) { auto s = hipMemcpy(&host_alpha, alpha, sizeof(double), hipMemcpyDefault); }
+  else { host_alpha = *alpha; }
+  H4I::MKLShim::dAxpy(ctxt, n, host_alpha, x, incx, y, incy);
+  HIPBLAS_CATCH("AXPY_64")
+}
+
+hipblasStatus_t hipblasScopy_64(hipblasHandle_t handle, int64_t n, const float* x, int64_t incx,
+                                float* y, int64_t incy) {
+  HIPBLAS_TRY
+  if (handle == nullptr || x == nullptr || y == nullptr || incx <= 0 || incy <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  H4I::MKLShim::sCopy(ctxt, n, x, incx, y, incy);
+  HIPBLAS_CATCH("COPY_64")
+}
+
+hipblasStatus_t hipblasDcopy_64(hipblasHandle_t handle, int64_t n, const double* x, int64_t incx,
+                                double* y, int64_t incy) {
+  HIPBLAS_TRY
+  if (handle == nullptr || x == nullptr || y == nullptr || incx <= 0 || incy <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  H4I::MKLShim::dCopy(ctxt, n, x, incx, y, incy);
+  HIPBLAS_CATCH("COPY_64")
+}
+
+hipblasStatus_t hipblasSscal_64(hipblasHandle_t handle, int64_t n, const float* alpha,
+                                float* x, int64_t incx) {
+  HIPBLAS_TRY
+  if (handle == nullptr || x == nullptr || alpha == nullptr || incx <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipblasPointerMode_t pointerMode;
+  hipblasGetPointerMode(handle, &pointerMode);
+  bool is_dev_ptr = (pointerMode == HIPBLAS_POINTER_MODE_DEVICE);
+  float host_alpha = 1.0;
+  if (is_dev_ptr) { auto s = hipMemcpy(&host_alpha, alpha, sizeof(float), hipMemcpyDefault); }
+  else { host_alpha = *alpha; }
+  H4I::MKLShim::sScal(ctxt, n, host_alpha, x, incx);
+  HIPBLAS_CATCH("SCAL_64")
+}
+
+hipblasStatus_t hipblasDscal_64(hipblasHandle_t handle, int64_t n, const double* alpha,
+                                double* x, int64_t incx) {
+  HIPBLAS_TRY
+  if (handle == nullptr || x == nullptr || alpha == nullptr || incx <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipblasPointerMode_t pointerMode;
+  hipblasGetPointerMode(handle, &pointerMode);
+  bool is_dev_ptr = (pointerMode == HIPBLAS_POINTER_MODE_DEVICE);
+  double host_alpha = 1.0;
+  if (is_dev_ptr) { auto s = hipMemcpy(&host_alpha, alpha, sizeof(double), hipMemcpyDefault); }
+  else { host_alpha = *alpha; }
+  H4I::MKLShim::dScal(ctxt, n, host_alpha, x, incx);
+  HIPBLAS_CATCH("SCAL_64")
+}
+
+hipblasStatus_t hipblasSnrm2_64(hipblasHandle_t handle, int64_t n, const float* x, int64_t incx,
+                                float* result) {
+  HIPBLAS_TRY
+  if (handle == nullptr || x == nullptr || result == nullptr || incx <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipError_t status;
+  hipblasPointerMode_t pointerMode;
+  hipblasGetPointerMode(handle, &pointerMode);
+  bool is_result_dev_ptr = (pointerMode == HIPBLAS_POINTER_MODE_DEVICE);
+  float* dev_result = result;
+  if (!is_result_dev_ptr) { status = hipMalloc(&dev_result, sizeof(float)); }
+  H4I::MKLShim::sNrm2(ctxt, n, x, incx, dev_result);
+  if (!is_result_dev_ptr) {
+    status = hipMemcpy(result, dev_result, sizeof(float), hipMemcpyDefault);
+    status = hipFree(dev_result);
+  }
+  HIPBLAS_CATCH("NRM2_64")
+}
+
+hipblasStatus_t hipblasDnrm2_64(hipblasHandle_t handle, int64_t n, const double* x, int64_t incx,
+                                double* result) {
+  HIPBLAS_TRY
+  if (handle == nullptr || x == nullptr || result == nullptr || incx <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipError_t status;
+  hipblasPointerMode_t pointerMode;
+  hipblasGetPointerMode(handle, &pointerMode);
+  bool is_result_dev_ptr = (pointerMode == HIPBLAS_POINTER_MODE_DEVICE);
+  double* dev_result = result;
+  if (!is_result_dev_ptr) { status = hipMalloc(&dev_result, sizeof(double)); }
+  H4I::MKLShim::dNrm2(ctxt, n, x, incx, dev_result);
+  if (!is_result_dev_ptr) {
+    status = hipMemcpy(result, dev_result, sizeof(double), hipMemcpyDefault);
+    status = hipFree(dev_result);
+  }
+  HIPBLAS_CATCH("NRM2_64")
+}
+
+hipblasStatus_t hipblasIsamax_64(hipblasHandle_t handle, int64_t n, const float* x, int64_t incx,
+                                 int64_t* result) {
+  HIPBLAS_TRY
+  hipError_t hip_status;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipblasPointerMode_t pointerMode;
+  hipblasGetPointerMode(handle, &pointerMode);
+  bool is_result_dev_ptr = (pointerMode == HIPBLAS_POINTER_MODE_DEVICE);
+  if (x == nullptr) {
+    if (is_result_dev_ptr) { hipMemset(result, 0, sizeof(int64_t)); }
+    else { *result = 0; }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+  if (handle == nullptr || result == nullptr || incx <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  int64_t *dev_results = nullptr;
+  hip_status = hipMalloc(&dev_results, sizeof(int64_t));
+  H4I::MKLShim::sAmax(ctxt, n, x, incx, dev_results);
+  int64_t results_host_memory = 0;
+  hip_status = hipMemcpy(&results_host_memory, dev_results, sizeof(int64_t), hipMemcpyDefault);
+  if (!H4I::MKLShim::is_mkl_eq_higher_2023_0_2()) { results_host_memory += 1; }
+  if (is_result_dev_ptr) { hipMemcpy(result, &results_host_memory, sizeof(int64_t), hipMemcpyDefault); }
+  else { *result = results_host_memory; }
+  hip_status = hipFree(dev_results);
+  HIPBLAS_CATCH("AMAX_64")
+}
+
+hipblasStatus_t hipblasIdamax_64(hipblasHandle_t handle, int64_t n, const double* x, int64_t incx,
+                                 int64_t* result) {
+  HIPBLAS_TRY
+  hipError_t hip_status;
+  auto* ctxt = static_cast<H4I::MKLShim::Context*>(handle);
+  hipblasPointerMode_t pointerMode;
+  hipblasGetPointerMode(handle, &pointerMode);
+  bool is_result_dev_ptr = (pointerMode == HIPBLAS_POINTER_MODE_DEVICE);
+  if (x == nullptr) {
+    if (is_result_dev_ptr) { hipMemset(result, 0, sizeof(int64_t)); }
+    else { *result = 0; }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+  if (handle == nullptr || result == nullptr || incx <= 0 || n <= 0)
+    return HIPBLAS_STATUS_INVALID_VALUE;
+  int64_t *dev_results = nullptr;
+  hip_status = hipMalloc(&dev_results, sizeof(int64_t));
+  H4I::MKLShim::dAmax(ctxt, n, x, incx, dev_results);
+  int64_t results_host_memory = 0;
+  hip_status = hipMemcpy(&results_host_memory, dev_results, sizeof(int64_t), hipMemcpyDefault);
+  if (!H4I::MKLShim::is_mkl_eq_higher_2023_0_2()) { results_host_memory += 1; }
+  if (is_result_dev_ptr) { hipMemcpy(result, &results_host_memory, sizeof(int64_t), hipMemcpyDefault); }
+  else { *result = results_host_memory; }
+  hip_status = hipFree(dev_results);
+  HIPBLAS_CATCH("AMAX_64")
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,3 +21,8 @@ add_test(NAME h4i-hipblas_context_test COMMAND hipblas_context_test)
 add_test(NAME h4i-hipblas_simple_batched_test COMMAND hipblas_simple_batched_test)
 add_test(NAME h4i-hipblas_batched_correctness_test COMMAND hipblas_batched_correctness_test)
 
+# ILP64 (_64) Level 1 BLAS tests
+add_executable(hipblas_blas1_64_test blas1_64_test.cpp)
+target_link_libraries(hipblas_blas1_64_test PRIVATE hipblas hip::host)
+target_include_directories(hipblas_blas1_64_test PRIVATE ${CMAKE_BINARY_DIR}/include)
+add_test(NAME h4i-hipblas_blas1_64_test COMMAND hipblas_blas1_64_test)

--- a/test/blas1_64_test.cpp
+++ b/test/blas1_64_test.cpp
@@ -1,0 +1,208 @@
+// Test ILP64 (_64) Level 1 BLAS functions.
+// Runs each _64 function on small vectors and verifies results against
+// known-good values computed on the host.
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <hip/hip_runtime.h>
+#include "hipblas.h"
+
+#define CHECK_HIP(expr) do { \
+    hipError_t e = (expr); \
+    if (e != hipSuccess) { \
+      std::cerr << #expr " failed: " << hipGetErrorString(e) \
+                << " at line " << __LINE__ << "\n"; \
+      return EXIT_FAILURE; \
+    } \
+  } while (0)
+
+#define CHECK_BLAS(expr) do { \
+    hipblasStatus_t s = (expr); \
+    if (s != HIPBLAS_STATUS_SUCCESS) { \
+      std::cerr << #expr " failed: status=" << s \
+                << " at line " << __LINE__ << "\n"; \
+      return EXIT_FAILURE; \
+    } \
+  } while (0)
+
+static bool near(double a, double b, double tol = 1e-12) {
+  return std::fabs(a - b) <= tol * (1.0 + std::fabs(b));
+}
+
+int main() {
+  const int64_t N = 8;
+  // Host vectors
+  double hx[N], hy[N];
+  for (int64_t i = 0; i < N; i++) {
+    hx[i] = (double)(i + 1);          // 1,2,3,...,8
+    hy[i] = (double)(N - i);           // 8,7,6,...,1
+  }
+
+  // Device vectors
+  double *dx, *dy;
+  CHECK_HIP(hipMalloc(&dx, N * sizeof(double)));
+  CHECK_HIP(hipMalloc(&dy, N * sizeof(double)));
+  CHECK_HIP(hipMemcpy(dx, hx, N * sizeof(double), hipMemcpyHostToDevice));
+  CHECK_HIP(hipMemcpy(dy, hy, N * sizeof(double), hipMemcpyHostToDevice));
+
+  hipblasHandle_t handle;
+  CHECK_BLAS(hipblasCreate(&handle));
+  CHECK_BLAS(hipblasSetPointerMode(handle, HIPBLAS_POINTER_MODE_HOST));
+
+  int pass = 0, fail = 0;
+
+  // --- Dasum_64 ---
+  {
+    double result = 0;
+    CHECK_BLAS(hipblasDasum_64(handle, N, dx, 1, &result));
+    // sum |1|+|2|+...+|8| = 36
+    if (near(result, 36.0)) { pass++; std::cout << "PASS Dasum_64: " << result << "\n"; }
+    else { fail++; std::cerr << "FAIL Dasum_64: expected 36, got " << result << "\n"; }
+  }
+
+  // --- Dnrm2_64 ---
+  {
+    double result = 0;
+    CHECK_BLAS(hipblasDnrm2_64(handle, N, dx, 1, &result));
+    // sqrt(1+4+9+16+25+36+49+64) = sqrt(204)
+    double expected = std::sqrt(204.0);
+    if (near(result, expected)) { pass++; std::cout << "PASS Dnrm2_64: " << result << "\n"; }
+    else { fail++; std::cerr << "FAIL Dnrm2_64: expected " << expected << ", got " << result << "\n"; }
+  }
+
+  // --- Idamax_64 ---
+  {
+    int64_t result = -1;
+    CHECK_BLAS(hipblasIdamax_64(handle, N, dx, 1, &result));
+    // max element is 8 at index 7 (0-based) -> hipBLAS returns 1-based = 8
+    if (result == 8) { pass++; std::cout << "PASS Idamax_64: " << result << "\n"; }
+    else { fail++; std::cerr << "FAIL Idamax_64: expected 8, got " << result << "\n"; }
+  }
+
+  // --- Dscal_64 ---
+  {
+    // Scale dy by 2.0: [8,7,...,1] -> [16,14,...,2]
+    CHECK_HIP(hipMemcpy(dy, hy, N * sizeof(double), hipMemcpyHostToDevice));
+    double alpha = 2.0;
+    CHECK_BLAS(hipblasDscal_64(handle, N, &alpha, dy, 1));
+    double hout[N];
+    CHECK_HIP(hipMemcpy(hout, dy, N * sizeof(double), hipMemcpyDeviceToHost));
+    bool ok = true;
+    for (int64_t i = 0; i < N; i++) {
+      if (!near(hout[i], 2.0 * hy[i])) { ok = false; break; }
+    }
+    if (ok) { pass++; std::cout << "PASS Dscal_64: [" << hout[0] << "," << hout[1] << ",...," << hout[N-1] << "]\n"; }
+    else { fail++; std::cerr << "FAIL Dscal_64\n"; }
+  }
+
+  // --- Dcopy_64 ---
+  {
+    double *dz;
+    CHECK_HIP(hipMalloc(&dz, N * sizeof(double)));
+    CHECK_HIP(hipMemset(dz, 0, N * sizeof(double)));
+    CHECK_BLAS(hipblasDcopy_64(handle, N, dx, 1, dz, 1));
+    double hout[N];
+    CHECK_HIP(hipMemcpy(hout, dz, N * sizeof(double), hipMemcpyDeviceToHost));
+    bool ok = true;
+    for (int64_t i = 0; i < N; i++) {
+      if (!near(hout[i], hx[i])) { ok = false; break; }
+    }
+    if (ok) { pass++; std::cout << "PASS Dcopy_64\n"; }
+    else { fail++; std::cerr << "FAIL Dcopy_64\n"; }
+    CHECK_HIP(hipFree(dz));
+  }
+
+  // --- Daxpy_64 ---
+  {
+    // y = alpha*x + y, alpha=3.0, x=[1..8], y=[8..1] -> [11,13,15,17,19,21,23,25]
+    CHECK_HIP(hipMemcpy(dy, hy, N * sizeof(double), hipMemcpyHostToDevice));
+    double alpha = 3.0;
+    CHECK_BLAS(hipblasDaxpy_64(handle, N, &alpha, dx, 1, dy, 1));
+    double hout[N];
+    CHECK_HIP(hipMemcpy(hout, dy, N * sizeof(double), hipMemcpyDeviceToHost));
+    bool ok = true;
+    for (int64_t i = 0; i < N; i++) {
+      double expected = 3.0 * hx[i] + hy[i];
+      if (!near(hout[i], expected)) { ok = false; std::cerr << "  i=" << i << " expected=" << expected << " got=" << hout[i] << "\n"; break; }
+    }
+    if (ok) { pass++; std::cout << "PASS Daxpy_64: [" << hout[0] << "," << hout[1] << ",...," << hout[N-1] << "]\n"; }
+    else { fail++; std::cerr << "FAIL Daxpy_64\n"; }
+  }
+
+  // --- Now float variants ---
+
+  float hxf[N], hyf[N];
+  for (int64_t i = 0; i < N; i++) {
+    hxf[i] = (float)(i + 1);
+    hyf[i] = (float)(N - i);
+  }
+  float *dxf, *dyf;
+  CHECK_HIP(hipMalloc(&dxf, N * sizeof(float)));
+  CHECK_HIP(hipMalloc(&dyf, N * sizeof(float)));
+  CHECK_HIP(hipMemcpy(dxf, hxf, N * sizeof(float), hipMemcpyHostToDevice));
+  CHECK_HIP(hipMemcpy(dyf, hyf, N * sizeof(float), hipMemcpyHostToDevice));
+
+  // --- Sasum_64 ---
+  {
+    float result = 0;
+    CHECK_BLAS(hipblasSasum_64(handle, N, dxf, 1, &result));
+    if (near(result, 36.0f, 1e-5)) { pass++; std::cout << "PASS Sasum_64: " << result << "\n"; }
+    else { fail++; std::cerr << "FAIL Sasum_64: expected 36, got " << result << "\n"; }
+  }
+
+  // --- Snrm2_64 ---
+  {
+    float result = 0;
+    CHECK_BLAS(hipblasSnrm2_64(handle, N, dxf, 1, &result));
+    float expected = std::sqrt(204.0f);
+    if (near(result, expected, 1e-5)) { pass++; std::cout << "PASS Snrm2_64: " << result << "\n"; }
+    else { fail++; std::cerr << "FAIL Snrm2_64: expected " << expected << ", got " << result << "\n"; }
+  }
+
+  // --- Isamax_64 ---
+  {
+    int64_t result = -1;
+    CHECK_BLAS(hipblasIsamax_64(handle, N, dxf, 1, &result));
+    if (result == 8) { pass++; std::cout << "PASS Isamax_64: " << result << "\n"; }
+    else { fail++; std::cerr << "FAIL Isamax_64: expected 8, got " << result << "\n"; }
+  }
+
+  // --- Sscal_64 ---
+  {
+    CHECK_HIP(hipMemcpy(dyf, hyf, N * sizeof(float), hipMemcpyHostToDevice));
+    float alpha = 2.0f;
+    CHECK_BLAS(hipblasSscal_64(handle, N, &alpha, dyf, 1));
+    float hout[N];
+    CHECK_HIP(hipMemcpy(hout, dyf, N * sizeof(float), hipMemcpyDeviceToHost));
+    bool ok = true;
+    for (int64_t i = 0; i < N; i++) {
+      if (!near(hout[i], 2.0f * hyf[i], 1e-5)) { ok = false; break; }
+    }
+    if (ok) { pass++; std::cout << "PASS Sscal_64\n"; }
+    else { fail++; std::cerr << "FAIL Sscal_64\n"; }
+  }
+
+  // --- Scopy_64 ---
+  {
+    float *dzf;
+    CHECK_HIP(hipMalloc(&dzf, N * sizeof(float)));
+    CHECK_HIP(hipMemset(dzf, 0, N * sizeof(float)));
+    CHECK_BLAS(hipblasScopy_64(handle, N, dxf, 1, dzf, 1));
+    float hout[N];
+    CHECK_HIP(hipMemcpy(hout, dzf, N * sizeof(float), hipMemcpyDeviceToHost));
+    bool ok = true;
+    for (int64_t i = 0; i < N; i++) {
+      if (!near(hout[i], hxf[i], 1e-5)) { ok = false; break; }
+    }
+    if (ok) { pass++; std::cout << "PASS Scopy_64\n"; }
+    else { fail++; std::cerr << "FAIL Scopy_64\n"; }
+    CHECK_HIP(hipFree(dzf));
+  }
+
+  // --- Saxpy_64 ---
+  {
+    CHECK_HIP(hipMemcpy(dyf, hyf, N * sizeof(float), hipMemcpyHostToDevice));
+    float alpha = 3.0f;
+    CHECK_BLAS(hipblasSaxpy_64(handle, N, &alpha, dxf, 1, dyf, 1));


### PR DESCRIPTION
## Summary

- The `hipblas.h` header declares `_64` variants (with `int64_t` arguments) for all Level 1 BLAS functions, but the library never implemented them
- This causes link failures for projects like [libCEED](https://github.com/CEED/libCEED) that use the `_64` API (introduced in libCEED upstream commit `832a6d73`)
- Adds 12 thin wrappers that delegate to the existing `int32` implementations:
  `hipblas{S,D}asum_64`, `hipblas{S,D}axpy_64`, `hipblas{S,D}copy_64`,
  `hipblas{S,D}scal_64`, `hipblas{S,D}nrm2_64`, `hipblasI{s,d}amax_64`

The `Isamax_64`/`Idamax_64` wrappers handle the `int` → `int64_t` result widening.

## Test plan

- [x] Builds cleanly against chipStar main (LLVM 21)
- [x] libCEED links and 280/284 HIP tests pass (4 failures are pre-existing unrelated bugs)
- [x] Verified all 12 symbols are exported with C linkage via `nm -D`