### PR TITLE
Add in ability to do no-pivot factorization, a getrs bug fix, and more tests

### DIFF
--- a/src/hipblas.cpp
+++ b/src/hipblas.cpp
@@ -9672,7 +9672,7 @@ hipblasStatus_t hipblasDgetrfBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || info == nullptr ||
       n <= 0 || lda < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -9684,6 +9684,27 @@ hipblasStatus_t hipblasDgetrfBatched(hipblasHandle_t handle,
   int64_t lda64 = lda;
   int64_t group_size = batchCount;
   
+  // ipiv == nullptr: caller requested a factorization with no pivoting. use getrfnp_batch
+  if (ipiv == nullptr) {
+    auto np_scratch_size = H4I::MKLShim::Dgetrfnp_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
+    if (np_scratch_size < 0) {
+      return HIPBLAS_STATUS_INTERNAL_ERROR;
+    }
+    double* np_scratch_device = nullptr;
+    if (np_scratch_size > 0) {
+      hipMalloc(&np_scratch_device, np_scratch_size * sizeof(double));
+    }
+    H4I::MKLShim::Dgetrfnp_batch(ctxt, &n64, &n64, (double**)A, &lda64,
+                                 group_count, &group_size, np_scratch_device, np_scratch_size);
+
+    std::vector<int> info_host(batchCount, 0);
+    hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
+    if (np_scratch_device) {
+      hipFree(np_scratch_device);
+    }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+
   // Calculate scratchpad size
   auto scratch_size = H4I::MKLShim::Dgetrf_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
   if (scratch_size < 0) {
@@ -9724,7 +9745,7 @@ hipblasStatus_t hipblasDgetrfBatched(hipblasHandle_t handle,
     hipMemcpy(ipiv + i * n, ipiv_batch.data(), n * sizeof(int), hipMemcpyHostToDevice);
     hipFree(ipiv_ptrs_host[i]);
   }
-  
+
   // Set info to 0 (success) for all batches - copy to device
   std::vector<int> info_host(batchCount, 0);
   hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
@@ -9748,7 +9769,7 @@ hipblasStatus_t hipblasDgetriBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || C == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || C == nullptr || info == nullptr ||
       n <= 0 || lda < n || ldc < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -9782,11 +9803,18 @@ hipblasStatus_t hipblasDgetriBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting, generate an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -9804,9 +9832,9 @@ hipblasStatus_t hipblasDgetriBatched(hipblasHandle_t handle,
     hipMemcpy(C_ptrs_host[i], A_ptrs_host[i], n * ldc * sizeof(double), hipMemcpyDeviceToDevice);
   }
   
-  H4I::MKLShim::Dgetri_batch(ctxt, &n64, (double**)C, &ldc64, ipiv_ptrs_device, 
+  H4I::MKLShim::Dgetri_batch(ctxt, &n64, (double**)C, &ldc64, ipiv_ptrs_device,
                             group_count, &group_size, scratch_device, scratch_size);
-  
+
   // Set info to 0 (success) for all batches - copy to device
   std::vector<int> info_host(batchCount, 0);
   hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
@@ -9835,7 +9863,7 @@ hipblasStatus_t hipblasDgetrsBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || B == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || B == nullptr || info == nullptr ||
       n <= 0 || nrhs <= 0 || lda < n || ldb < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -9873,11 +9901,18 @@ hipblasStatus_t hipblasDgetrsBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting requested, use an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -9887,11 +9922,10 @@ hipblasStatus_t hipblasDgetrsBatched(hipblasHandle_t handle,
   H4I::MKLShim::Dgetrs_batch(ctxt, &trans_array, &n64, &nrhs64, (double**)A, &lda64, 
                             ipiv_ptrs_device, (double**)B, &ldb64, group_count, &group_size, 
                             scratch_device, scratch_size);
-  
-  // Set info to 0 (success) for all batches - copy to device
-  std::vector<int> info_host(batchCount, 0);
-  hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
-  
+
+  // Set info to 0 (success)
+  *info = 0;
+
   // Cleanup
   for (int i = 0; i < batchCount; i++) {
     hipFree(ipiv_ptrs_host[i]);
@@ -9900,7 +9934,7 @@ hipblasStatus_t hipblasDgetrsBatched(hipblasHandle_t handle,
   if (scratch_device) {
     hipFree(scratch_device);
   }
-  
+
   HIPBLAS_CATCH("DGETRSBATCHED")
 }
 
@@ -9912,7 +9946,7 @@ hipblasStatus_t hipblasZgetrfBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || info == nullptr ||
       n <= 0 || lda < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -9924,6 +9958,27 @@ hipblasStatus_t hipblasZgetrfBatched(hipblasHandle_t handle,
   int64_t lda64 = lda;
   int64_t group_size = batchCount;
   
+  // ipiv == nullptr: caller requested a factorization with no pivoting. use getrfnp_batch
+  if (ipiv == nullptr) {
+    auto np_scratch_size = H4I::MKLShim::Zgetrfnp_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
+    if (np_scratch_size < 0) {
+      return HIPBLAS_STATUS_INTERNAL_ERROR;
+    }
+    double _Complex* np_scratch_device = nullptr;
+    if (np_scratch_size > 0) {
+      hipMalloc(&np_scratch_device, np_scratch_size * sizeof(double _Complex));
+    }
+    H4I::MKLShim::Zgetrfnp_batch(ctxt, &n64, &n64, (double _Complex**)A, &lda64,
+                                 group_count, &group_size, np_scratch_device, np_scratch_size);
+
+    std::vector<int> info_host(batchCount, 0);
+    hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
+    if (np_scratch_device) {
+      hipFree(np_scratch_device);
+    }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+
   // Calculate scratchpad size
   auto scratch_size = H4I::MKLShim::Zgetrf_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
   if (scratch_size < 0) {
@@ -9964,7 +10019,7 @@ hipblasStatus_t hipblasZgetrfBatched(hipblasHandle_t handle,
     hipMemcpy(ipiv + i * n, ipiv_batch.data(), n * sizeof(int), hipMemcpyHostToDevice);
     hipFree(ipiv_ptrs_host[i]);
   }
-  
+
   // Set info to 0 (success) for all batches - copy to device
   std::vector<int> info_host(batchCount, 0);
   hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
@@ -9988,7 +10043,7 @@ hipblasStatus_t hipblasZgetriBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || C == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || C == nullptr || info == nullptr ||
       n <= 0 || lda < n || ldc < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10022,11 +10077,18 @@ hipblasStatus_t hipblasZgetriBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting, generate an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -10075,7 +10137,7 @@ hipblasStatus_t hipblasZgetrsBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || B == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || B == nullptr || info == nullptr ||
       n <= 0 || nrhs <= 0 || lda < n || ldb < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10113,11 +10175,18 @@ hipblasStatus_t hipblasZgetrsBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting, generate an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -10127,11 +10196,10 @@ hipblasStatus_t hipblasZgetrsBatched(hipblasHandle_t handle,
   H4I::MKLShim::Zgetrs_batch(ctxt, &trans_array, &n64, &nrhs64, (double _Complex**)A, &lda64, 
                             ipiv_ptrs_device, (double _Complex**)B, &ldb64, group_count, &group_size, 
                             scratch_device, scratch_size);
-  
-  // Set info to 0 (success) for all batches - copy to device
-  std::vector<int> info_host(batchCount, 0);
-  hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
-  
+
+  // Set info to 0 (success)
+  *info = 0;
+
   // Cleanup
   for (int i = 0; i < batchCount; i++) {
     hipFree(ipiv_ptrs_host[i]);
@@ -10140,7 +10208,7 @@ hipblasStatus_t hipblasZgetrsBatched(hipblasHandle_t handle,
   if (scratch_device) {
     hipFree(scratch_device);
   }
-  
+
   HIPBLAS_CATCH("ZGETRSBATCHED")
 }
 
@@ -10154,7 +10222,7 @@ hipblasStatus_t hipblasSgetrfBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || info == nullptr ||
       n <= 0 || lda < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10166,6 +10234,27 @@ hipblasStatus_t hipblasSgetrfBatched(hipblasHandle_t handle,
   int64_t lda64 = lda;
   int64_t group_size = batchCount;
   
+  // ipiv == nullptr: caller requested a factorization with no pivoting. use getrfnp_batch
+  if (ipiv == nullptr) {
+    auto np_scratch_size = H4I::MKLShim::Sgetrfnp_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
+    if (np_scratch_size < 0) {
+      return HIPBLAS_STATUS_INTERNAL_ERROR;
+    }
+    float* np_scratch_device = nullptr;
+    if (np_scratch_size > 0) {
+      hipMalloc(&np_scratch_device, np_scratch_size * sizeof(float));
+    }
+    H4I::MKLShim::Sgetrfnp_batch(ctxt, &n64, &n64, (float**)A, &lda64,
+                                 group_count, &group_size, np_scratch_device, np_scratch_size);
+
+    std::vector<int> info_host(batchCount, 0);
+    hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
+    if (np_scratch_device) {
+      hipFree(np_scratch_device);
+    }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+
   // Calculate scratchpad size
   auto scratch_size = H4I::MKLShim::Sgetrf_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
   if (scratch_size < 0) {
@@ -10206,7 +10295,7 @@ hipblasStatus_t hipblasSgetrfBatched(hipblasHandle_t handle,
     hipMemcpy(ipiv + i * n, ipiv_batch.data(), n * sizeof(int), hipMemcpyHostToDevice);
     hipFree(ipiv_ptrs_host[i]);
   }
-  
+
   // Set info to 0 (success) for all batches - copy to device
   std::vector<int> info_host(batchCount, 0);
   hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
@@ -10230,7 +10319,7 @@ hipblasStatus_t hipblasSgetriBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || C == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || C == nullptr || info == nullptr ||
       n <= 0 || lda < n || ldc < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10264,11 +10353,18 @@ hipblasStatus_t hipblasSgetriBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting, generate an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -10317,7 +10413,7 @@ hipblasStatus_t hipblasSgetrsBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || B == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || B == nullptr || info == nullptr ||
       n <= 0 || nrhs <= 0 || lda < n || ldb < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10355,11 +10451,18 @@ hipblasStatus_t hipblasSgetrsBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting, generate an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -10369,11 +10472,9 @@ hipblasStatus_t hipblasSgetrsBatched(hipblasHandle_t handle,
   H4I::MKLShim::Sgetrs_batch(ctxt, &trans_array, &n64, &nrhs64, (float**)A, &lda64, 
                             ipiv_ptrs_device, (float**)B, &ldb64, group_count, &group_size, 
                             scratch_device, scratch_size);
-  
-  // Set info to 0 (success) for all batches - copy to device
-  std::vector<int> info_host(batchCount, 0);
-  hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
-  
+
+  *info = 0;
+
   // Cleanup
   for (int i = 0; i < batchCount; i++) {
     hipFree(ipiv_ptrs_host[i]);
@@ -10382,7 +10483,7 @@ hipblasStatus_t hipblasSgetrsBatched(hipblasHandle_t handle,
   if (scratch_device) {
     hipFree(scratch_device);
   }
-  
+
   HIPBLAS_CATCH("SGETRSBATCHED")
 }
 
@@ -10396,7 +10497,7 @@ hipblasStatus_t hipblasCgetrfBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || info == nullptr ||
       n <= 0 || lda < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10408,6 +10509,27 @@ hipblasStatus_t hipblasCgetrfBatched(hipblasHandle_t handle,
   int64_t lda64 = lda;
   int64_t group_size = batchCount;
   
+  // ipiv == nullptr: caller requested a factorization with no pivoting. use getrfnp_batch
+  if (ipiv == nullptr) {
+    auto np_scratch_size = H4I::MKLShim::Cgetrfnp_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
+    if (np_scratch_size < 0) {
+      return HIPBLAS_STATUS_INTERNAL_ERROR;
+    }
+    float _Complex* np_scratch_device = nullptr;
+    if (np_scratch_size > 0) {
+      hipMalloc(&np_scratch_device, np_scratch_size * sizeof(float _Complex));
+    }
+    H4I::MKLShim::Cgetrfnp_batch(ctxt, &n64, &n64, (float _Complex**)A, &lda64,
+                                 group_count, &group_size, np_scratch_device, np_scratch_size);
+
+    std::vector<int> info_host(batchCount, 0);
+    hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
+    if (np_scratch_device) {
+      hipFree(np_scratch_device);
+    }
+    return HIPBLAS_STATUS_SUCCESS;
+  }
+
   // Calculate scratchpad size
   auto scratch_size = H4I::MKLShim::Cgetrf_batch_ScPadSz(ctxt, group_count, &n64, &n64, &lda64, &group_size);
   if (scratch_size < 0) {
@@ -10448,7 +10570,7 @@ hipblasStatus_t hipblasCgetrfBatched(hipblasHandle_t handle,
     hipMemcpy(ipiv + i * n, ipiv_batch.data(), n * sizeof(int), hipMemcpyHostToDevice);
     hipFree(ipiv_ptrs_host[i]);
   }
-  
+
   // Set info to 0 (success) for all batches - copy to device
   std::vector<int> info_host(batchCount, 0);
   hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
@@ -10472,7 +10594,7 @@ hipblasStatus_t hipblasCgetriBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || C == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || C == nullptr || info == nullptr ||
       n <= 0 || lda < n || ldc < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10506,11 +10628,18 @@ hipblasStatus_t hipblasCgetriBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting, generate an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -10559,7 +10688,7 @@ hipblasStatus_t hipblasCgetrsBatched(hipblasHandle_t handle,
                                     int* info,
                                     const int batchCount) {
   HIPBLAS_TRY
-  if (handle == nullptr || A == nullptr || ipiv == nullptr || B == nullptr || info == nullptr ||
+  if (handle == nullptr || A == nullptr || B == nullptr || info == nullptr ||
       n <= 0 || nrhs <= 0 || lda < n || ldb < n || batchCount <= 0) {
     return HIPBLAS_STATUS_INVALID_VALUE;
   }
@@ -10597,11 +10726,18 @@ hipblasStatus_t hipblasCgetrsBatched(hipblasHandle_t handle,
     int64_t* ipiv_i;
     hipMalloc(&ipiv_i, n * sizeof(int64_t));
     std::vector<int64_t> ipiv_temp(n);
-    std::vector<int> ipiv_host(n);
-    // Copy ipiv data from device to host first
-    hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
-    for (int j = 0; j < n; j++) {
-      ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+    if (ipiv != nullptr) {
+      std::vector<int> ipiv_host(n);
+      // Copy ipiv data from device to host first
+      hipMemcpy(ipiv_host.data(), ipiv + i * n, n * sizeof(int), hipMemcpyDeviceToHost);
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(ipiv_host[j]);
+      }
+    } else {
+      // ipiv == nullptr, no-pivoting, generate an identity pivot
+      for (int j = 0; j < n; j++) {
+        ipiv_temp[j] = static_cast<int64_t>(j + 1);
+      }
     }
     hipMemcpy(ipiv_i, ipiv_temp.data(), n * sizeof(int64_t), hipMemcpyHostToDevice);
     ipiv_ptrs_host[i] = ipiv_i;
@@ -10611,11 +10747,9 @@ hipblasStatus_t hipblasCgetrsBatched(hipblasHandle_t handle,
   H4I::MKLShim::Cgetrs_batch(ctxt, &trans_array, &n64, &nrhs64, (float _Complex**)A, &lda64, 
                             ipiv_ptrs_device, (float _Complex**)B, &ldb64, group_count, &group_size, 
                             scratch_device, scratch_size);
-  
-  // Set info to 0 (success) for all batches - copy to device
-  std::vector<int> info_host(batchCount, 0);
-  hipMemcpy(info, info_host.data(), batchCount * sizeof(int), hipMemcpyHostToDevice);
-  
+
+  *info = 0;
+
   // Cleanup
   for (int i = 0; i < batchCount; i++) {
     hipFree(ipiv_ptrs_host[i]);
@@ -10624,7 +10758,7 @@ hipblasStatus_t hipblasCgetrsBatched(hipblasHandle_t handle,
   if (scratch_device) {
     hipFree(scratch_device);
   }
-  
+
   HIPBLAS_CATCH("CGETRSBATCHED")
 }
 

--- a/test/batched_correctness_test.cpp
+++ b/test/batched_correctness_test.cpp
@@ -529,6 +529,570 @@ void applyRowPermutations(std::vector<T>& mat, const int* piv, int n, int lda)
     }
 }
 
+// ===========================================================================
+// Additional getri (batched matrix-inverse) coverage.
+// getri inverts from the LU factors, so each test runs getrf then getri and
+// verifies A_orig * inv(A) ~= I (column-major). Reuses the helpers above.
+// ===========================================================================
+
+// generic double getri correctness for one (n, batchCount)
+static bool runDgetriCorrectness(int n, int batchCount, unsigned seed) {
+    const int lda = n, ldc = n;
+    hipblasHandle_t handle;
+    CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+
+    std::vector<std::vector<double>> A_host(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> A_orig(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> C_host(batchCount, std::vector<double>(ldc * n));
+    std::mt19937 gen(seed);
+    for (int b = 0; b < batchCount; ++b) {
+        generateRandomMatrix(A_host[b], n, n, lda, gen);
+        makeDiagonallyDominant(A_host[b], n, lda);
+        A_orig[b] = A_host[b];
+    }
+
+    std::vector<double*> A_ptrs(batchCount), C_ptrs(batchCount);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMalloc(&A_ptrs[b], lda * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMalloc(&C_ptrs[b], ldc * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMemcpy(A_ptrs[b], A_host[b].data(), lda * n * sizeof(double),
+                                   hipMemcpyHostToDevice));
+    }
+    double **A_arr = nullptr, **C_arr = nullptr; int *ipiv = nullptr, *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&C_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&ipiv,  batchCount * n * sizeof(int)));
+    CHECK_HIP_STATUS(hipMalloc(&info,  batchCount * sizeof(int)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, A_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(C_arr, C_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+
+    CHECK_HIPBLAS_STATUS(hipblasDgetrfBatched(handle, n, A_arr, lda, ipiv, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasDgetriBatched(handle, n, A_arr, lda, ipiv, C_arr, ldc, info, batchCount));
+
+    bool ok = true;
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMemcpy(C_host[b].data(), C_ptrs[b], ldc * n * sizeof(double),
+                                   hipMemcpyDeviceToHost));
+        std::vector<double> R(n * n, 0.0);
+        cpu_gemm(false, false, n, n, n, 1.0, A_orig[b].data(), lda, C_host[b].data(), ldc, 0.0, R.data(), n);
+        for (int i = 0; i < n && ok; ++i)
+            for (int j = 0; j < n && ok; ++j) {
+                double expected = (i == j) ? 1.0 : 0.0;
+                if (std::abs(R[j * n + i] - expected) > TOLERANCE_DOUBLE) ok = false;
+            }
+    }
+
+    for (int b = 0; b < batchCount; ++b) { hipFree(A_ptrs[b]); hipFree(C_ptrs[b]); }
+    hipFree(A_arr); hipFree(C_arr); hipFree(ipiv); hipFree(info);
+    hipblasDestroy(handle);
+    return ok;
+}
+
+// sweep sizes (incl. 1x1) and batch counts
+bool testDgetriSizesAndBatches() {
+    std::cout << "Testing hipblasDgetriBatched across sizes/batch counts..." << std::endl;
+    const int sizes[]   = {1, 2, 5, 16, 32};
+    const int batches[] = {1, 4, 16};
+    bool ok = true;
+    for (int n : sizes)
+        for (int bc : batches) {
+            bool r = runDgetriCorrectness(n, bc, 100u + 31u * (unsigned)n + (unsigned)bc);
+            std::cout << "  n=" << n << " batch=" << bc << " : " << (r ? "ok" : "FAIL") << std::endl;
+            ok = ok && r;
+        }
+    if (ok) std::cout << "hipblasDgetriBatched sizes/batches test PASSED" << std::endl;
+    return ok;
+}
+
+// known analytic inverse (exact values)
+bool testDgetriKnownInverse() {
+    std::cout << "Testing hipblasDgetriBatched known 2x2 inverse..." << std::endl;
+    const int n = 2, lda = 2, ldc = 2, batchCount = 1;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+    // A = [[4,3],[6,3]] ; inv(A) = [[-1/2, 1/2],[1, -2/3]]  (column-major)
+    std::vector<double> A           = {4.0, 6.0, 3.0, 3.0};
+    std::vector<double> expectedInv = {-0.5, 1.0, 0.5, -2.0/3.0};
+
+    double *dA = nullptr, *dC = nullptr, **A_arr = nullptr, **C_arr = nullptr;
+    int *ipiv = nullptr, *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&dA, 4 * sizeof(double)));
+    CHECK_HIP_STATUS(hipMalloc(&dC, 4 * sizeof(double)));
+    CHECK_HIP_STATUS(hipMemcpy(dA, A.data(), 4 * sizeof(double), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&C_arr, sizeof(double*)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, &dA, sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(C_arr, &dC, sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMalloc(&ipiv, n * sizeof(int)));
+    CHECK_HIP_STATUS(hipMalloc(&info, sizeof(int)));
+
+    CHECK_HIPBLAS_STATUS(hipblasDgetrfBatched(handle, n, A_arr, lda, ipiv, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasDgetriBatched(handle, n, A_arr, lda, ipiv, C_arr, ldc, info, batchCount));
+
+    std::vector<double> C(4);
+    CHECK_HIP_STATUS(hipMemcpy(C.data(), dC, 4 * sizeof(double), hipMemcpyDeviceToHost));
+    bool ok = compareArrays(C.data(), expectedInv.data(), 4, TOLERANCE_DOUBLE);
+
+    hipFree(dA); hipFree(dC); hipFree(A_arr); hipFree(C_arr); hipFree(ipiv); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "hipblasDgetriBatched known-inverse test PASSED" << std::endl;
+    return ok;
+}
+
+// single precision Sgetri correctness
+bool testSgetriBatched() {
+    std::cout << "Testing hipblasSgetriBatched..." << std::endl;
+    const int n = 6, lda = n, ldc = n, batchCount = 4;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+
+    std::vector<std::vector<float>> A_host(batchCount, std::vector<float>(lda * n));
+    std::vector<std::vector<float>> A_orig(batchCount, std::vector<float>(lda * n));
+    std::vector<std::vector<float>> C_host(batchCount, std::vector<float>(ldc * n));
+    std::mt19937 gen(777);
+    for (int b = 0; b < batchCount; ++b) {
+        generateRandomMatrix(A_host[b], n, n, lda, gen);
+        makeDiagonallyDominant(A_host[b], n, lda);
+        A_orig[b] = A_host[b];
+    }
+    std::vector<float*> A_ptrs(batchCount), C_ptrs(batchCount);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMalloc(&A_ptrs[b], lda * n * sizeof(float)));
+        CHECK_HIP_STATUS(hipMalloc(&C_ptrs[b], ldc * n * sizeof(float)));
+        CHECK_HIP_STATUS(hipMemcpy(A_ptrs[b], A_host[b].data(), lda * n * sizeof(float), hipMemcpyHostToDevice));
+    }
+    float **A_arr = nullptr, **C_arr = nullptr; int *ipiv = nullptr, *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, batchCount * sizeof(float*)));
+    CHECK_HIP_STATUS(hipMalloc(&C_arr, batchCount * sizeof(float*)));
+    CHECK_HIP_STATUS(hipMalloc(&ipiv,  batchCount * n * sizeof(int)));
+    CHECK_HIP_STATUS(hipMalloc(&info,  batchCount * sizeof(int)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, A_ptrs.data(), batchCount * sizeof(float*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(C_arr, C_ptrs.data(), batchCount * sizeof(float*), hipMemcpyHostToDevice));
+
+    CHECK_HIPBLAS_STATUS(hipblasSgetrfBatched(handle, n, A_arr, lda, ipiv, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasSgetriBatched(handle, n, A_arr, lda, ipiv, C_arr, ldc, info, batchCount));
+
+    bool ok = true;
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMemcpy(C_host[b].data(), C_ptrs[b], ldc * n * sizeof(float), hipMemcpyDeviceToHost));
+        std::vector<float> R(n * n, 0.0f);
+        cpu_gemm(false, false, n, n, n, 1.0f, A_orig[b].data(), lda, C_host[b].data(), ldc, 0.0f, R.data(), n);
+        for (int i = 0; i < n && ok; ++i)
+            for (int j = 0; j < n && ok; ++j) {
+                float expected = (i == j) ? 1.0f : 0.0f;
+                if (std::abs(R[j * n + i] - expected) > TOLERANCE_FLOAT) ok = false;
+            }
+    }
+    for (int b = 0; b < batchCount; ++b) { hipFree(A_ptrs[b]); hipFree(C_ptrs[b]); }
+    hipFree(A_arr); hipFree(C_arr); hipFree(ipiv); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "hipblasSgetriBatched test PASSED" << std::endl;
+    return ok;
+}
+
+// getri with heavy row pivoting. Diagonally-dominant matrices don't pivot
+// (identity ipiv), so they don't exercise the int->int64 ipiv conversion.
+// Here we row-reverse a diagonally-dominant matrix: the dominant entries move
+// off the diagonal, forcing getrf to perform non-trivial row swaps. A_orig*inv
+// ~= I only holds if those pivots are converted and applied correctly.
+bool testDgetriPivoting() {
+    std::cout << "Testing hipblasDgetriBatched with row pivoting..." << std::endl;
+    const int n = 6, lda = n, ldc = n, batchCount = 4;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+
+    std::vector<std::vector<double>> A_host(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> A_orig(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> C_host(batchCount, std::vector<double>(ldc * n));
+    std::mt19937 gen(4242);
+    for (int b = 0; b < batchCount; ++b) {
+        std::vector<double> M(lda * n);
+        generateRandomMatrix(M, n, n, lda, gen);
+        makeDiagonallyDominant(M, n, lda);
+        // Reverse row order -> dominant entries land off-diagonal -> forces pivoting.
+        for (int j = 0; j < n; ++j)
+            for (int i = 0; i < n; ++i)
+                A_host[b][j * lda + i] = M[j * lda + (n - 1 - i)];
+        A_orig[b] = A_host[b];
+    }
+
+    std::vector<double*> A_ptrs(batchCount), C_ptrs(batchCount);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMalloc(&A_ptrs[b], lda * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMalloc(&C_ptrs[b], ldc * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMemcpy(A_ptrs[b], A_host[b].data(), lda * n * sizeof(double),
+                                   hipMemcpyHostToDevice));
+    }
+    double **A_arr = nullptr, **C_arr = nullptr; int *ipiv = nullptr, *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&C_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&ipiv,  batchCount * n * sizeof(int)));
+    CHECK_HIP_STATUS(hipMalloc(&info,  batchCount * sizeof(int)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, A_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(C_arr, C_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+
+    CHECK_HIPBLAS_STATUS(hipblasDgetrfBatched(handle, n, A_arr, lda, ipiv, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasDgetriBatched(handle, n, A_arr, lda, ipiv, C_arr, ldc, info, batchCount));
+
+    // Sanity: pivots should be non-trivial (some ipiv[k] != k+1) for at least one matrix.
+    std::vector<int> ipiv_host(batchCount * n);
+    CHECK_HIP_STATUS(hipMemcpy(ipiv_host.data(), ipiv, batchCount * n * sizeof(int), hipMemcpyDeviceToHost));
+    bool anyPivot = false;
+    for (int b = 0; b < batchCount; ++b)
+        for (int k = 0; k < n; ++k)
+            if (ipiv_host[b * n + k] != k + 1) anyPivot = true;
+    if (!anyPivot)
+        std::cout << "  note: no row swaps occurred (ipiv was identity)" << std::endl;
+
+    bool ok = true;
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMemcpy(C_host[b].data(), C_ptrs[b], ldc * n * sizeof(double),
+                                   hipMemcpyDeviceToHost));
+        std::vector<double> R(n * n, 0.0);
+        cpu_gemm(false, false, n, n, n, 1.0, A_orig[b].data(), lda, C_host[b].data(), ldc, 0.0, R.data(), n);
+        for (int i = 0; i < n && ok; ++i)
+            for (int j = 0; j < n && ok; ++j) {
+                double expected = (i == j) ? 1.0 : 0.0;
+                if (std::abs(R[j * n + i] - expected) > TOLERANCE_DOUBLE) ok = false;
+            }
+    }
+    for (int b = 0; b < batchCount; ++b) { hipFree(A_ptrs[b]); hipFree(C_ptrs[b]); }
+    hipFree(A_arr); hipFree(C_arr); hipFree(ipiv); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "hipblasDgetriBatched pivoting test PASSED" << std::endl;
+    return ok;
+}
+
+// ===========================================================================
+// getrs (batched solve A X = B using the LU factors from getrf) coverage.
+// Each test runs getrf then getrs (X overwrites B) and verifies
+// op(A_orig) * X ~= B_orig (column-major). Reuses the helpers above.
+// ===========================================================================
+
+static bool runDgetrsCorrectness(hipblasOperation_t trans, int n, int nrhs,
+                                 int batchCount, unsigned seed) {
+    const int lda = n, ldb = n;
+    hipblasHandle_t handle;
+    CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+
+    std::vector<std::vector<double>> A_host(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> A_orig(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> B_host(batchCount, std::vector<double>(ldb * nrhs));
+    std::vector<std::vector<double>> B_orig(batchCount, std::vector<double>(ldb * nrhs));
+    std::mt19937 gen(seed);
+    for (int b = 0; b < batchCount; ++b) {
+        generateRandomMatrix(A_host[b], n, n, lda, gen);
+        makeDiagonallyDominant(A_host[b], n, lda);
+        A_orig[b] = A_host[b];
+        generateRandomMatrix(B_host[b], n, nrhs, ldb, gen);
+        B_orig[b] = B_host[b];
+    }
+
+    std::vector<double*> A_ptrs(batchCount), B_ptrs(batchCount);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMalloc(&A_ptrs[b], lda * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMalloc(&B_ptrs[b], ldb * nrhs * sizeof(double)));
+        CHECK_HIP_STATUS(hipMemcpy(A_ptrs[b], A_host[b].data(), lda * n * sizeof(double), hipMemcpyHostToDevice));
+        CHECK_HIP_STATUS(hipMemcpy(B_ptrs[b], B_host[b].data(), ldb * nrhs * sizeof(double), hipMemcpyHostToDevice));
+    }
+    double **A_arr = nullptr, **B_arr = nullptr; int *ipiv = nullptr, *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&B_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&ipiv,  batchCount * n * sizeof(int)));
+    CHECK_HIP_STATUS(hipMalloc(&info,  batchCount * sizeof(int)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, A_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(B_arr, B_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+
+    int info_getrs = 0;  // getrsBatched info is a single host int
+    CHECK_HIPBLAS_STATUS(hipblasDgetrfBatched(handle, n, A_arr, lda, ipiv, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasDgetrsBatched(handle, trans, n, nrhs, A_arr, lda, ipiv,
+                                              B_arr, ldb, &info_getrs, batchCount));
+
+    bool ok = true;
+    const bool tr = (trans != HIPBLAS_OP_N);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMemcpy(B_host[b].data(), B_ptrs[b], ldb * nrhs * sizeof(double),
+                                   hipMemcpyDeviceToHost));
+        // R = op(A_orig) * X, compare to original RHS B_orig.
+        std::vector<double> R(n * nrhs, 0.0);
+        cpu_gemm(tr, false, n, nrhs, n, 1.0, A_orig[b].data(), lda, B_host[b].data(), ldb, 0.0, R.data(), n);
+        for (int j = 0; j < nrhs && ok; ++j)
+            for (int i = 0; i < n && ok; ++i)
+                if (std::abs(R[j * n + i] - B_orig[b][j * ldb + i]) > TOLERANCE_DOUBLE) ok = false;
+    }
+    for (int b = 0; b < batchCount; ++b) { hipFree(A_ptrs[b]); hipFree(B_ptrs[b]); }
+    hipFree(A_arr); hipFree(B_arr); hipFree(ipiv); hipFree(info);
+    hipblasDestroy(handle);
+    return ok;
+}
+
+// sweep sizes / right-hand-side counts / batch counts (solve A X = B)
+bool testDgetrsBatched() {
+    std::cout << "Testing hipblasDgetrsBatched (A X = B) across sizes/nrhs/batch..." << std::endl;
+    const int sizes[]   = {1, 3, 8, 16};
+    const int nrhss[]   = {1, 4};
+    const int batches[] = {1, 8};
+    bool ok = true;
+    for (int n : sizes)
+      for (int nrhs : nrhss)
+        for (int bc : batches) {
+            bool r = runDgetrsCorrectness(HIPBLAS_OP_N, n, nrhs, bc,
+                                          200u + 7u * (unsigned)n + (unsigned)nrhs + (unsigned)bc);
+            std::cout << "  n=" << n << " nrhs=" << nrhs << " batch=" << bc
+                      << " : " << (r ? "ok" : "FAIL") << std::endl;
+            ok = ok && r;
+        }
+    if (ok) std::cout << "hipblasDgetrsBatched test PASSED" << std::endl;
+    return ok;
+}
+
+// transpose solve: A^T X = B
+bool testDgetrsTranspose() {
+    std::cout << "Testing hipblasDgetrsBatched transpose (A^T X = B)..." << std::endl;
+    bool ok = runDgetrsCorrectness(HIPBLAS_OP_T, 8, 3, 4, 9090u);
+    if (ok) std::cout << "hipblasDgetrsBatched transpose test PASSED" << std::endl;
+    return ok;
+}
+
+// known solution: A=[[4,3],[6,3]], X=[1;2] -> B = A*X = [10;12]; solve must recover X.
+bool testDgetrsKnownSolution() {
+    std::cout << "Testing hipblasDgetrsBatched known solution..." << std::endl;
+    const int n = 2, nrhs = 1, lda = 2, ldb = 2, batchCount = 1;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+    std::vector<double> A = {4.0, 6.0, 3.0, 3.0};   // col-major
+    std::vector<double> B = {10.0, 12.0};           // = A * [1;2]
+    std::vector<double> Xexpected = {1.0, 2.0};
+
+    double *dA = nullptr, *dB = nullptr, **A_arr = nullptr, **B_arr = nullptr;
+    int *ipiv = nullptr, *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&dA, 4 * sizeof(double)));
+    CHECK_HIP_STATUS(hipMalloc(&dB, 2 * sizeof(double)));
+    CHECK_HIP_STATUS(hipMemcpy(dA, A.data(), 4 * sizeof(double), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(dB, B.data(), 2 * sizeof(double), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&B_arr, sizeof(double*)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, &dA, sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(B_arr, &dB, sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMalloc(&ipiv, n * sizeof(int)));
+    CHECK_HIP_STATUS(hipMalloc(&info, sizeof(int)));
+
+    int info_getrs = 0;  // getrsBatched info is a single host int
+    CHECK_HIPBLAS_STATUS(hipblasDgetrfBatched(handle, n, A_arr, lda, ipiv, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasDgetrsBatched(handle, HIPBLAS_OP_N, n, nrhs, A_arr, lda, ipiv,
+                                              B_arr, ldb, &info_getrs, batchCount));
+    std::vector<double> X(2);
+    CHECK_HIP_STATUS(hipMemcpy(X.data(), dB, 2 * sizeof(double), hipMemcpyDeviceToHost));
+    bool ok = compareArrays(X.data(), Xexpected.data(), 2, TOLERANCE_DOUBLE);
+
+    hipFree(dA); hipFree(dB); hipFree(A_arr); hipFree(B_arr); hipFree(ipiv); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "hipblasDgetrsBatched known-solution test PASSED" << std::endl;
+    return ok;
+}
+
+// single precision Sgetrs
+bool testSgetrsBatched() {
+    std::cout << "Testing hipblasSgetrsBatched..." << std::endl;
+    const int n = 6, nrhs = 2, lda = n, ldb = n, batchCount = 4;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+
+    std::vector<std::vector<float>> A_host(batchCount, std::vector<float>(lda * n));
+    std::vector<std::vector<float>> A_orig(batchCount, std::vector<float>(lda * n));
+    std::vector<std::vector<float>> B_host(batchCount, std::vector<float>(ldb * nrhs));
+    std::vector<std::vector<float>> B_orig(batchCount, std::vector<float>(ldb * nrhs));
+    std::mt19937 gen(5151);
+    for (int b = 0; b < batchCount; ++b) {
+        generateRandomMatrix(A_host[b], n, n, lda, gen);
+        makeDiagonallyDominant(A_host[b], n, lda);
+        A_orig[b] = A_host[b];
+        generateRandomMatrix(B_host[b], n, nrhs, ldb, gen);
+        B_orig[b] = B_host[b];
+    }
+    std::vector<float*> A_ptrs(batchCount), B_ptrs(batchCount);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMalloc(&A_ptrs[b], lda * n * sizeof(float)));
+        CHECK_HIP_STATUS(hipMalloc(&B_ptrs[b], ldb * nrhs * sizeof(float)));
+        CHECK_HIP_STATUS(hipMemcpy(A_ptrs[b], A_host[b].data(), lda * n * sizeof(float), hipMemcpyHostToDevice));
+        CHECK_HIP_STATUS(hipMemcpy(B_ptrs[b], B_host[b].data(), ldb * nrhs * sizeof(float), hipMemcpyHostToDevice));
+    }
+    float **A_arr = nullptr, **B_arr = nullptr; int *ipiv = nullptr, *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, batchCount * sizeof(float*)));
+    CHECK_HIP_STATUS(hipMalloc(&B_arr, batchCount * sizeof(float*)));
+    CHECK_HIP_STATUS(hipMalloc(&ipiv,  batchCount * n * sizeof(int)));
+    CHECK_HIP_STATUS(hipMalloc(&info,  batchCount * sizeof(int)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, A_ptrs.data(), batchCount * sizeof(float*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(B_arr, B_ptrs.data(), batchCount * sizeof(float*), hipMemcpyHostToDevice));
+
+    int info_getrs = 0;  // getrsBatched info is a single host int
+    CHECK_HIPBLAS_STATUS(hipblasSgetrfBatched(handle, n, A_arr, lda, ipiv, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasSgetrsBatched(handle, HIPBLAS_OP_N, n, nrhs, A_arr, lda, ipiv,
+                                              B_arr, ldb, &info_getrs, batchCount));
+    bool ok = true;
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMemcpy(B_host[b].data(), B_ptrs[b], ldb * nrhs * sizeof(float), hipMemcpyDeviceToHost));
+        std::vector<float> R(n * nrhs, 0.0f);
+        cpu_gemm(false, false, n, nrhs, n, 1.0f, A_orig[b].data(), lda, B_host[b].data(), ldb, 0.0f, R.data(), n);
+        for (int j = 0; j < nrhs && ok; ++j)
+            for (int i = 0; i < n && ok; ++i)
+                if (std::abs(R[j * n + i] - B_orig[b][j * ldb + i]) > TOLERANCE_FLOAT) ok = false;
+    }
+    for (int b = 0; b < batchCount; ++b) { hipFree(A_ptrs[b]); hipFree(B_ptrs[b]); }
+    hipFree(A_arr); hipFree(B_arr); hipFree(ipiv); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "hipblasSgetrsBatched test PASSED" << std::endl;
+    return ok;
+}
+
+// ===========================================================================
+// ipiv == nullptr (no-pivoting) workflow.
+//   getrf with ipiv=nullptr performs a true LU factorization WITHOUT pivoting
+//   via MKL's getrfnp_batch.
+//   - On a matrix that needs no pivoting (diagonally dominant), getrf+getri and
+//     getrf+getrs with ipiv=nullptr must succeed and be correct.
+//   - On a matrix that partial-pivoting WOULD swap but that still has a valid
+//     no-pivot LU (all leading principal minors nonzero), getrf with
+//     ipiv=nullptr must now succeed and produce a correct factorization.
+// ===========================================================================
+
+bool testDgetriNoPivot() {
+    std::cout << "Testing getrf+getri with ipiv=nullptr (no-pivot)..." << std::endl;
+    const int n = 6, lda = n, ldc = n, batchCount = 4;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+    std::vector<std::vector<double>> A_host(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> A_orig(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> C_host(batchCount, std::vector<double>(ldc * n));
+    std::mt19937 gen(31337);
+    for (int b = 0; b < batchCount; ++b) {
+        generateRandomMatrix(A_host[b], n, n, lda, gen);
+        makeDiagonallyDominant(A_host[b], n, lda);     // no pivoting needed
+        A_orig[b] = A_host[b];
+    }
+    std::vector<double*> A_ptrs(batchCount), C_ptrs(batchCount);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMalloc(&A_ptrs[b], lda * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMalloc(&C_ptrs[b], ldc * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMemcpy(A_ptrs[b], A_host[b].data(), lda * n * sizeof(double), hipMemcpyHostToDevice));
+    }
+    double **A_arr = nullptr, **C_arr = nullptr; int *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&C_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&info, batchCount * sizeof(int)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, A_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(C_arr, C_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+
+    CHECK_HIPBLAS_STATUS(hipblasDgetrfBatched(handle, n, A_arr, lda, nullptr, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasDgetriBatched(handle, n, A_arr, lda, nullptr, C_arr, ldc, info, batchCount));
+
+    bool ok = true;
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMemcpy(C_host[b].data(), C_ptrs[b], ldc * n * sizeof(double), hipMemcpyDeviceToHost));
+        std::vector<double> R(n * n, 0.0);
+        cpu_gemm(false, false, n, n, n, 1.0, A_orig[b].data(), lda, C_host[b].data(), ldc, 0.0, R.data(), n);
+        for (int i = 0; i < n && ok; ++i)
+            for (int j = 0; j < n && ok; ++j) {
+                double e = (i == j) ? 1.0 : 0.0;
+                if (std::abs(R[j * n + i] - e) > TOLERANCE_DOUBLE) ok = false;
+            }
+    }
+    for (int b = 0; b < batchCount; ++b) { hipFree(A_ptrs[b]); hipFree(C_ptrs[b]); }
+    hipFree(A_arr); hipFree(C_arr); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "getrf+getri ipiv=nullptr (no-pivot) test PASSED" << std::endl;
+    return ok;
+}
+
+bool testDgetrsNoPivot() {
+    std::cout << "Testing getrf+getrs with ipiv=nullptr (no-pivot)..." << std::endl;
+    const int n = 6, nrhs = 2, lda = n, ldb = n, batchCount = 4;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+    std::vector<std::vector<double>> A_host(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> A_orig(batchCount, std::vector<double>(lda * n));
+    std::vector<std::vector<double>> B_host(batchCount, std::vector<double>(ldb * nrhs));
+    std::vector<std::vector<double>> B_orig(batchCount, std::vector<double>(ldb * nrhs));
+    std::mt19937 gen(24680);
+    for (int b = 0; b < batchCount; ++b) {
+        generateRandomMatrix(A_host[b], n, n, lda, gen);
+        makeDiagonallyDominant(A_host[b], n, lda);
+        A_orig[b] = A_host[b];
+        generateRandomMatrix(B_host[b], n, nrhs, ldb, gen);
+        B_orig[b] = B_host[b];
+    }
+    std::vector<double*> A_ptrs(batchCount), B_ptrs(batchCount);
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMalloc(&A_ptrs[b], lda * n * sizeof(double)));
+        CHECK_HIP_STATUS(hipMalloc(&B_ptrs[b], ldb * nrhs * sizeof(double)));
+        CHECK_HIP_STATUS(hipMemcpy(A_ptrs[b], A_host[b].data(), lda * n * sizeof(double), hipMemcpyHostToDevice));
+        CHECK_HIP_STATUS(hipMemcpy(B_ptrs[b], B_host[b].data(), ldb * nrhs * sizeof(double), hipMemcpyHostToDevice));
+    }
+    double **A_arr = nullptr, **B_arr = nullptr; int *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&B_arr, batchCount * sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&info, batchCount * sizeof(int)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, A_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(B_arr, B_ptrs.data(), batchCount * sizeof(double*), hipMemcpyHostToDevice));
+
+    int info_getrs = 0;  // getrsBatched info is a single host int
+    CHECK_HIPBLAS_STATUS(hipblasDgetrfBatched(handle, n, A_arr, lda, nullptr, info, batchCount));
+    CHECK_HIPBLAS_STATUS(hipblasDgetrsBatched(handle, HIPBLAS_OP_N, n, nrhs, A_arr, lda, nullptr,
+                                              B_arr, ldb, &info_getrs, batchCount));
+    bool ok = true;
+    for (int b = 0; b < batchCount; ++b) {
+        CHECK_HIP_STATUS(hipMemcpy(B_host[b].data(), B_ptrs[b], ldb * nrhs * sizeof(double), hipMemcpyDeviceToHost));
+        std::vector<double> R(n * nrhs, 0.0);
+        cpu_gemm(false, false, n, nrhs, n, 1.0, A_orig[b].data(), lda, B_host[b].data(), ldb, 0.0, R.data(), n);
+        for (int j = 0; j < nrhs && ok; ++j)
+            for (int i = 0; i < n && ok; ++i)
+                if (std::abs(R[j * n + i] - B_orig[b][j * ldb + i]) > TOLERANCE_DOUBLE) ok = false;
+    }
+    for (int b = 0; b < batchCount; ++b) { hipFree(A_ptrs[b]); hipFree(B_ptrs[b]); }
+    hipFree(A_arr); hipFree(B_arr); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "getrf+getrs ipiv=nullptr (no-pivot) test PASSED" << std::endl;
+    return ok;
+}
+
+// A = [[1,2],[3,4]]: partial pivoting WOULD swap rows (|3| > |1|), but a
+// no-pivot LU exists (leading minors 1 and det=-2 are nonzero). With
+// getrfnp_batch, getrf(ipiv=nullptr) must now SUCCEED and yield a correct
+// factorization. We verify by inverting (getri, ipiv=nullptr) and checking
+// A * A^-1 == I.
+bool testDgetrfNoPivotSucceedsWhenPivotWouldHappen() {
+    std::cout << "Testing getrf ipiv=nullptr succeeds on a pivotable matrix with valid no-pivot LU..." << std::endl;
+    const int n = 2, lda = 2, ldc = 2, batchCount = 1;
+    hipblasHandle_t handle; CHECK_HIPBLAS_STATUS(hipblasCreate(&handle));
+    // A = [[1,2],[3,4]] in column-major.
+    std::vector<double> A = {1.0, 3.0, 2.0, 4.0};
+    std::vector<double> A_orig = A;
+    double *dA = nullptr, *dC = nullptr, **A_arr = nullptr, **C_arr = nullptr; int *info = nullptr;
+    CHECK_HIP_STATUS(hipMalloc(&dA, 4 * sizeof(double)));
+    CHECK_HIP_STATUS(hipMalloc(&dC, 4 * sizeof(double)));
+    CHECK_HIP_STATUS(hipMemcpy(dA, A.data(), 4 * sizeof(double), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMalloc(&A_arr, sizeof(double*)));
+    CHECK_HIP_STATUS(hipMalloc(&C_arr, sizeof(double*)));
+    CHECK_HIP_STATUS(hipMemcpy(A_arr, &dA, sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMemcpy(C_arr, &dC, sizeof(double*), hipMemcpyHostToDevice));
+    CHECK_HIP_STATUS(hipMalloc(&info, sizeof(int)));
+
+    hipblasStatus_t st = hipblasDgetrfBatched(handle, n, A_arr, lda, nullptr, info, batchCount);
+    bool ok = (st == HIPBLAS_STATUS_SUCCESS);
+    if (!ok) std::cerr << "  getrf(ipiv=nullptr) expected SUCCESS, got " << (int)st << std::endl;
+    if (ok) {
+        CHECK_HIPBLAS_STATUS(hipblasDgetriBatched(handle, n, A_arr, lda, nullptr, C_arr, ldc, info, batchCount));
+        std::vector<double> C(4);
+        CHECK_HIP_STATUS(hipMemcpy(C.data(), dC, 4 * sizeof(double), hipMemcpyDeviceToHost));
+        std::vector<double> R(4, 0.0);
+        cpu_gemm(false, false, n, n, n, 1.0, A_orig.data(), lda, C.data(), ldc, 0.0, R.data(), n);
+        for (int i = 0; i < n && ok; ++i)
+            for (int j = 0; j < n && ok; ++j) {
+                double e = (i == j) ? 1.0 : 0.0;
+                if (std::abs(R[j * n + i] - e) > TOLERANCE_DOUBLE) ok = false;
+            }
+        if (!ok) std::cerr << "  A * A^-1 != I after no-pivot factorization" << std::endl;
+    }
+
+    hipFree(dA); hipFree(dC); hipFree(A_arr); hipFree(C_arr); hipFree(info);
+    hipblasDestroy(handle);
+    if (ok) std::cout << "getrf ipiv=nullptr pivotable-matrix test PASSED" << std::endl;
+    return ok;
+}
+
 int main() {
     std::cout << "=== Testing H4I-HipBLAS Batched LAPACK Functions ===" << std::endl << std::endl;
     
@@ -539,7 +1103,24 @@ int main() {
     allPassed &= testDgetriBatched();
     allPassed &= testCgetrfBatched();
     allPassed &= testSgemmStridedBatched();
-    
+
+    // Additional getri coverage
+    allPassed &= testDgetriSizesAndBatches();
+    allPassed &= testDgetriKnownInverse();
+    allPassed &= testDgetriPivoting();
+    allPassed &= testSgetriBatched();
+
+    // getrs (solve A X = B) coverage
+    allPassed &= testDgetrsBatched();
+    allPassed &= testDgetrsTranspose();
+    allPassed &= testDgetrsKnownSolution();
+    allPassed &= testSgetrsBatched();
+
+    // ipiv=nullptr (no-pivoting) workflow
+    allPassed &= testDgetriNoPivot();
+    allPassed &= testDgetrsNoPivot();
+    allPassed &= testDgetrfNoPivotSucceedsWhenPivotWouldHappen();
+
     std::cout << std::endl;
     if (allPassed) {
         std::cout << "ALL TESTS PASSED! Batched functions are working correctly." << std::endl;


### PR DESCRIPTION
This 1) adds in an options for no-pivoting,  2) fixes a bug in getrs_batch, and 3) adds some more tests, especially for pivoting.

1) As mentioned here: https://rocm.docs.amd.com/projects/hipBLAS/en/docs-5.3.3/source/functions.html#hipblasxgetrf-batched-stridedbatched if ipiv is passed in with a nullptr it means to do the factorization without a pivot array. Intel has this option (https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-dpcpp/2026-0/getrfnp-batch-group-version.html) and it's just been added to MKLShim layer (https://github.com/CHIP-SPV/H4I-MKLShim/pull/56). If a user passes in nullptr for ipiv for a hip*getrfbatched call, this will call MKL's getrfnp_batch API, and if a user passes in nullptr for ipiv for a hip*getr[is]batched call, this creates an identity pivot array to run with.

2) As mentioned here: https://rocm.docs.amd.com/projects/hipBLAS/en/docs-5.3.3/source/functions.html#hipblasxgetrs-batched-stridedbatched hip*getrsbatched , for getrsbatched, info is a `pointer to a int on the host.`. This is different from getrf or getri, which use device arrays. This PR changes getrs to use a host pointer as specified in the documentation.

3) This adds some Claude-generated tests to catch getrs issues and test more pivoting.