### PR TITLE
ci: run the test suite (ctest) in presubmit

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -96,3 +96,24 @@ jobs:
             -DBUILD_SAMPLES=OFF \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cmake --build build -j 8
+      - name: Test
+        shell: bash
+        run: |
+          set -e
+          if [ -f "$HOME/.local/init/bash" ]; then
+            export MODULESHOME=$HOME/.local
+            source "$MODULESHOME/init/bash"
+          elif [ -f /etc/profile.d/lmod.sh ]; then
+            source /etc/profile.d/lmod.sh
+          else
+            source /etc/profile.d/modules.sh
+          fi
+          module use /space/pvelesko/modulefiles
+          module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
+          export CMAKE_PREFIX_PATH="$DEPS/chipstar:$DEPS/mklshim:${CMAKE_PREFIX_PATH:-}"
+          export LD_LIBRARY_PATH="$DEPS/chipstar/lib:$DEPS/mklshim/lib:${LD_LIBRARY_PATH:-}"
+          # Batched getrf/getri/getrs tests run in double precision; the Arc A380
+          # has no native FP64, so enable IGC software emulation.
+          export IGC_EnableDPEmulation=1
+          export OverrideDefaultFP64Settings=1
+          ctest --test-dir build --output-on-failure


### PR DESCRIPTION
Presubmit built the tests but never ran them, so correctness regressions passed CI and only surfaced downstream in chipStar's libraries job. Adds a `Test` step running `ctest` after the build (FP64 emulation enabled for the double-precision batched solver tests).